### PR TITLE
Improve links for package listing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flex_color_scheme
 description: A Flutter package to use and make beautiful Material design based themes.
 version: 5.1.0
-homepage: https://github.com/rydmike/flex_color_scheme
+repository: https://github.com/rydmike/flex_color_scheme
 environment:
   sdk: '>=2.17.0 <3.0.0'
   flutter: '>=3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,7 @@ description: A Flutter package to use and make beautiful Material design based t
 version: 5.1.0
 repository: https://github.com/rydmike/flex_color_scheme
 issue_tracker: https://github.com/rydmike/flex_color_scheme/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+documentation: https://docs.flexcolorscheme.com/
 environment:
   sdk: '>=2.17.0 <3.0.0'
   flutter: '>=3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: flex_color_scheme
 description: A Flutter package to use and make beautiful Material design based themes.
 version: 5.1.0
 repository: https://github.com/rydmike/flex_color_scheme
+issue_tracker: https://github.com/rydmike/flex_color_scheme/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
 environment:
   sdk: '>=2.17.0 <3.0.0'
   flutter: '>=3.0.0'


### PR DESCRIPTION
Updates the pub.dev listing
- Adds issue tracker link
- Adds docs website link
- Changes the main link from "homepage" to "repository" - which makes it clearer to people browsing the package that there *is* a linked repo.

Old:

![image](https://user-images.githubusercontent.com/9575627/177870214-67b6242b-bd0e-4053-a10b-ed034747c60f.png)

New:

![image](https://user-images.githubusercontent.com/9575627/177870256-a8eb288c-0c13-4242-b20f-9c1c42976e6f.png)
