### PR TITLE
fix: #106 Use of incorrect value to get bottomSheetModalColor from schemeColor

### DIFF
--- a/lib/src/flex_color_scheme.dart
+++ b/lib/src/flex_color_scheme.dart
@@ -5669,7 +5669,7 @@ class FlexColorScheme with Diagnosticable {
     final Color bottomSheetModalColor =
         subTheme.bottomSheetModalBackgroundColor != null
             ? FlexSubThemes.schemeColor(
-                subTheme.bottomSheetBackgroundColor!, colorScheme)
+                subTheme.bottomSheetModalBackgroundColor!, colorScheme)
             : colorScheme.surface;
     final double bottomSheetElevation = subTheme.bottomSheetElevation ??
         (useMaterial3 ? kBottomSheetElevation : kBottomSheetElevationM2);


### PR DESCRIPTION
Fix the use of `subTheme.bottomSheetBackgroundColor` instead of `subTheme.bottomSheetModalBackgroundColor` when getting schemeColor for `bottomSheetModalBackgroundColor`